### PR TITLE
Add periodic Home Assistant discovery advertisement

### DIFF
--- a/occupancy.go
+++ b/occupancy.go
@@ -581,16 +581,32 @@ func main() {
 	cam_forwarder.MakeCamForwarder()
 	cam_forwarder.Start()
 	Logger.Info().Msg("ready")
-	go OnlinePinger() // start the online pinger
-	select {}         // block forever
+	go OnlinePinger()      // start the online pinger
+	go HAAdvertiser()      // start the HA advertisement pinger
+	select {}              // block forever
 }
 
 // online pinger
 func OnlinePinger() {
-	for {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	
+	for range ticker.C {
 		if token := Client.Publish("hab/online", 0, false, "online"); token.Wait() && token.Error() != nil {
 			Logger.Error().Msgf("Error publishing online message: %v", token.Error())
 		}
-		time.Sleep(10 * time.Second)
+	}
+}
+
+// HA advertiser - advertises Home Assistant discovery messages every 5 minutes
+func HAAdvertiser() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	
+	for range ticker.C {
+		if Client != nil && Client.IsConnected() {
+			Logger.Debug().Msg("Advertising Home Assistant discovery messages")
+			AdvertiseHA(model.Rooms, Client)
+		}
 	}
 }


### PR DESCRIPTION
## Overview
This PR adds periodic Home Assistant discovery message advertisement to ensure HA always has up-to-date device information.

## Changes
- **Added HAAdvertiser() function**: Runs as a goroutine and advertises HA discovery messages every 5 minutes while MQTT is connected
- **Updated OnlinePinger()**: Refactored to use 	ime.Ticker instead of 	ime.Sleep for more precise timing
- **Connection-aware advertising**: Only sends advertisements when MQTT client is actively connected
- **Proper resource management**: Both functions use defer ticker.Stop() for cleanup

## Benefits
- Home Assistant will maintain device discovery even after restarts
- More reliable device availability in HA
- Consistent timing patterns across periodic functions
- Better resource management with proper ticker cleanup

## Testing
- [x] Code compiles successfully
- [x] Follows project Go coding standards
- [x] Uses time.Ticker for precise interval timing
- [x] Includes proper MQTT connection checks

Resolves the issue where HA discovery messages were only sent on initial MQTT connection.