### PR TITLE
feat(deploy): add ServiceMonitor for Prometheus scraping

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -97,3 +97,18 @@ spec:
         - name: config-file
           configMap:
             name: home-controller-config
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: occupancy-controller
+  labels:
+    app: occupancy-controller
+spec:
+  selector:
+    matchLabels:
+      app: occupancy-controller
+  endpoints:
+    - port: monitoring
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
Adds a `ServiceMonitor` so the Prometheus Operator auto-discovers the `/metrics` endpoint shipped in #35.

- Selects `occupancy-controller-service` by `app: occupancy-controller`.
- Scrapes the service's `monitoring` port (→ container port 8888, `details_port`) at `/metrics`, every 30s.
- No custom selector label on the ServiceMonitor — relies on the cluster Prometheus using `serviceMonitorSelector: {}`.

Requires the Prometheus Operator CRDs to be present in the cluster (they are, per the chosen approach). ArgoCD will apply it alongside the existing Deployment/Service/Ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)